### PR TITLE
Create basic Flask site

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,25 @@
+from flask import Flask, render_template
+import markdown
+from pathlib import Path
+
+app = Flask(__name__)
+
+README_PATH = Path(__file__).parent / 'README.md'
+
+# Convert README markdown to HTML once at startup
+def load_readme():
+    text = README_PATH.read_text(encoding='utf-8')
+    html = markdown.markdown(
+        text,
+        extensions=['fenced_code', 'tables']
+    )
+    return html
+
+README_HTML = load_readme()
+
+@app.route('/')
+def index():
+    return render_template('index.html', content=README_HTML)
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/static/progress.js
+++ b/static/progress.js
@@ -1,0 +1,19 @@
+function saveProgress() {
+  const checkboxes = document.querySelectorAll('input[type="checkbox"]');
+  checkboxes.forEach((cb, idx) => {
+    localStorage.setItem('cb_'+idx, cb.checked);
+  });
+}
+
+function loadProgress() {
+  const checkboxes = document.querySelectorAll('input[type="checkbox"]');
+  checkboxes.forEach((cb, idx) => {
+    const saved = localStorage.getItem('cb_'+idx);
+    if (saved !== null) {
+      cb.checked = saved === 'true';
+    }
+    cb.addEventListener('change', saveProgress);
+  });
+}
+
+document.addEventListener('DOMContentLoaded', loadProgress);

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,28 @@
+:root {
+  --color-1: #42206D;
+  --color-2: #5A2471;
+  --color-3: #39265D;
+  --color-4: #660F56;
+  --color-5: #AB215B;
+  --color-6: #E64F6B;
+  --color-7: #F95A63;
+  --font-family: 'Roboto Mono', monospace;
+}
+
+body {
+  font-family: var(--font-family);
+  color: var(--color-3);
+  line-height: 1.5;
+}
+
+h1, h2, h3 {
+  font-weight: bold;
+}
+
+h1 { font-size: 2.5em; color: var(--color-1); }
+h2 { font-size: 2em;   color: var(--color-2); }
+h3 { font-size: 1.75em; color: var(--color-4); }
+
+.container {
+  margin: 20px;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="pt-br">
+<head>
+    <meta charset="UTF-8">
+    <title>Roadmap Cientista de Dados</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+    <div class="container">
+        {{ content|safe }}
+    </div>
+    <script src="{{ url_for('static', filename='progress.js') }}"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Flask app to render README as website
- store progress locally with JavaScript
- add stylesheet for roadmap

## Testing
- `python3 -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_686eb0d4a434832da87db38a656941c1