### PR TITLE
Add Vercel routes to avoid 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,8 +149,21 @@ O roadmap está organizado em 7 sessões, cada uma representando um bloco de est
 
 <div align="center">
 
-*Roadmap criado por Letycia Locha*  
-*Me siga nas redes sociais @pythonicah*  
+*Roadmap criado por Letycia Locha*
+*Me siga nas redes sociais @pythonicah*
 *2025*
 
 </div>
+
+## Deploying to Vercel
+
+1. Instale as dependências listadas em `requirements.txt`.
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Faça login na Vercel e execute o deploy:
+   ```bash
+   vercel --prod
+   ```
+   O arquivo `vercel.json` define que `app.py` será construído com `@vercel/python`
+   e mapeia todas as rotas para esse arquivo, evitando erros 404.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+markdown

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "builds": [
+    { "src": "app.py", "use": "@vercel/python" }
+  ],
+  "routes": [
+    { "src": "/(.*)", "dest": "app.py" }
+  ]
+}


### PR DESCRIPTION
## Summary
- route all traffic to `app.py` in `vercel.json`
- clarify deployment instructions in README about the routing

## Testing
- `python -m py_compile app.py`
- `pip install -q -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_686eb304e008832da8cbfd8efee03170