### PR TITLE
Fix: Add error handling for README.md loading

### DIFF
--- a/app.py
+++ b/app.py
@@ -8,12 +8,19 @@ README_PATH = Path(__file__).parent / 'README.md'
 
 # Convert README markdown to HTML once at startup
 def load_readme():
-    text = README_PATH.read_text(encoding='utf-8')
-    html = markdown.markdown(
-        text,
-        extensions=['fenced_code', 'tables']
-    )
-    return html
+    try:
+        text = README_PATH.read_text(encoding='utf-8')
+        html = markdown.markdown(
+            text,
+            extensions=['fenced_code', 'tables']
+        )
+        return html
+    except Exception as e:
+        # Log the error (Vercel will capture stdout/stderr for logs)
+        print(f"Error loading or parsing README.md: {e}")
+        # Return a fallback HTML or raise the exception
+        # For now, let's return a simple error message to be displayed on the page
+        return "<p>Error loading content. Please check the server logs.</p>"
 
 README_HTML = load_readme()
 


### PR DESCRIPTION
Introduces a try-except block in the `load_readme` function in `app.py`. This change aims to prevent a full function crash (500 error) if there's an issue reading or parsing the README.md file.

If an error occurs during this process, it will now be printed to the server logs (visible in Vercel logs) and a fallback HTML message will be displayed on the page, aiding in diagnostics.