### PR TITLE
Fix Werkzeug version for Flask 2.0 app

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 Flask==2.0.3
 Markdown==3.3.7
+Werkzeug<3.0
+


### PR DESCRIPTION
## Summary
- pin Werkzeug<3.0 to maintain compatibility with Flask 2.0

## Testing
- `python -m py_compile app.py`
- `python app.py` *(launched and terminated)*

------
https://chatgpt.com/codex/tasks/task_e_686ec65f9754832d950efcb8619ba674