### PR TITLE
Fix Werkzeug version for Flask 2.0 app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <div align="center">
 
-# Roadmap Cientista de Dados
+<h1>Roadmap Cientista de Dados</h1>
 
-**Pronta para iniciar sua jornada de estudos?**
+<h3>Pronta para iniciar sua jornada de estudos?</h3>
 
 <!-- Barra de progresso que salva o progresso do usuário com autenticação -->
 <div id="progress-container">

--- a/app.py
+++ b/app.py
@@ -1,6 +1,7 @@
 from flask import Flask, render_template
 import markdown
 from pathlib import Path
+import os
 
 app = Flask(__name__)
 
@@ -29,4 +30,5 @@ def index():
     return render_template('index.html', content=README_HTML)
 
 if __name__ == '__main__':
-    app.run(debug=True)
+    port = int(os.environ.get('PORT', 5000))
+    app.run(host='0.0.0.0', port=port, debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 Flask==2.0.3
 Markdown==3.3.7
+Werkzeug<3.0
+

--- a/static/progress.js
+++ b/static/progress.js
@@ -1,6 +1,57 @@
 // Default hours per item if not specified
 const DEFAULT_HOURS_PER_ITEM = 1;
 
+// Estimated hours per material. These values are approximations used for
+// progress calculation. If a title is not listed here the default will be used.
+const HOURS_PER_ITEM = {
+  // Bloco 1 – Análise de Dados
+  'Estatística I': 10,
+  'Estatística II': 10,
+  'Governança de Dados': 8,
+  'Excel para Ciência de Dados': 8,
+  'SQL Básico': 6,
+  'Projeto Excel': 15,
+  'Projeto SQL': 15,
+
+  // Bloco 2 – Programação
+  'Python I': 4,
+  'Python II': 6,
+  'SQL Intermediário': 6,
+  'EDA em SQL': 6,
+  'Projeto ETL': 15,
+
+  // Bloco 3 – EDA
+  'Data Analyst Track': 40,
+  'Associate Data Analyst': 40,
+  'Fundamentos DS': 20,
+  'Pandas': 6,
+  'Matplotlib': 4,
+  'Seaborn': 4,
+  'Projeto EDA': 15,
+
+  // Bloco 4 – Machine Learning
+  'Tópicos em ML': 10,
+  'Conceitos ML': 8,
+  'Projeto ML': 15,
+
+  // Bloco 5 – Ferramentas Avançadas
+  'Big Data Analytics': 8,
+  'Power BI Intro': 5,
+  'Apache Spark': 5,
+  'Curso Spark com PySpark': 20,
+  'Projeto Spark': 15,
+
+  // Bloco 6 – Deep Learning
+  'Deep Learning': 8,
+  'TensorFlow Docs': 6,
+  'TensorFlow Learn ML': 6,
+  'Projeto DL': 15,
+
+  // Bloco Final – Portfólio
+  'Git & GitHub na Prática': 4,
+  'Criando Portfólio': 4,
+};
+
 function updateProgressBar() {
   const checkboxes = document.querySelectorAll('td input[type="checkbox"]'); // Target only checkboxes in table cells
   const progressBar = document.getElementById('progress-bar');
@@ -57,18 +108,36 @@ function loadProgress() {
   updateProgressBar(); // Initial update of the bar on load
 }
 
+function initializeCheckboxes() {
+  // Convert textual "[ ]" into real checkbox inputs and attach hours metadata
+  const rows = document.querySelectorAll('table tbody tr');
+  rows.forEach(row => {
+    const cells = row.querySelectorAll('td');
+    if (cells.length === 0) return;
+    const firstCell = cells[0];
+    const text = firstCell.textContent.trim();
+    if (text === '[ ]' || text.toLowerCase() === '[x]') {
+      const title = cells[1] ? cells[1].textContent.trim() : '';
+      const checkbox = document.createElement('input');
+      checkbox.type = 'checkbox';
+      checkbox.checked = text.toLowerCase() === '[x]';
+      const hours = HOURS_PER_ITEM[title] || DEFAULT_HOURS_PER_ITEM;
+      checkbox.setAttribute('data-hours', hours);
+      firstCell.textContent = '';
+      firstCell.appendChild(checkbox);
+    }
+  });
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   // Ensure the progress bar HTML is present (it should be in the README converted HTML)
   const progressContainer = document.getElementById('progress-container');
   if (progressContainer && !document.getElementById('progress-bar')) {
     const bar = document.createElement('div');
     bar.id = 'progress-bar';
-    // Optional: Add ARIA attributes for accessibility
-    // bar.setAttribute('role', 'progressbar');
-    // bar.setAttribute('aria-valuenow', '0');
-    // bar.setAttribute('aria-valuemin', '0');
-    // bar.setAttribute('aria-valuemax', '100');
     progressContainer.appendChild(bar);
   }
+
+  initializeCheckboxes();
   loadProgress();
 });


### PR DESCRIPTION
## Summary
- pin Werkzeug<3.0 to maintain compatibility with Flask 2.0
- make markdown checkboxes interactive and track study hours
- adjust README header structure
- allow overriding port for local execution

## Testing
- `python -m py_compile app.py`
- `PORT=8000 python app.py` *(fails: Address already in use)

------
https://chatgpt.com/codex/tasks/task_e_686ec65f9754832d950efcb8619ba674