### PR TITLE
Add login persistence and responsive tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+progress_data.json
+__pycache__/

--- a/app.py
+++ b/app.py
@@ -1,11 +1,30 @@
-from flask import Flask, render_template
+from flask import Flask, render_template, request, redirect, url_for, session, jsonify
 import markdown
 from pathlib import Path
 import os
+import json
 
 app = Flask(__name__)
+app.secret_key = os.environ.get('SECRET_KEY', 'dev_secret_key')
+
+DATA_FILE = Path(__file__).parent / 'progress_data.json'
 
 README_PATH = Path(__file__).parent / 'README.md'
+
+# Simple JSON based storage for user progress
+def load_data():
+    if DATA_FILE.exists():
+        with open(DATA_FILE, 'r', encoding='utf-8') as f:
+            try:
+                return json.load(f)
+            except json.JSONDecodeError:
+                return {}
+    return {}
+
+
+def save_data(data):
+    with open(DATA_FILE, 'w', encoding='utf-8') as f:
+        json.dump(data, f)
 
 # Convert README markdown to HTML once at startup
 def load_readme():
@@ -27,7 +46,46 @@ README_HTML = load_readme()
 
 @app.route('/')
 def index():
-    return render_template('index.html', content=README_HTML)
+    username = session.get('username')
+    return render_template('index.html', content=README_HTML, username=username)
+
+
+@app.route('/login', methods=['GET', 'POST'])
+def login():
+    if request.method == 'POST':
+        username = request.form.get('username', '').strip()
+        if username:
+            session['username'] = username
+            data = load_data()
+            if username not in data:
+                data[username] = []
+                save_data(data)
+            return redirect(url_for('index'))
+    return render_template('login.html')
+
+
+@app.route('/logout')
+def logout():
+    session.pop('username', None)
+    return redirect(url_for('login'))
+
+
+@app.route('/progress', methods=['GET', 'POST'])
+def progress():
+    username = session.get('username')
+    if not username:
+        return jsonify({'error': 'Unauthorized'}), 401
+
+    data = load_data()
+
+    if request.method == 'POST':
+        payload = request.get_json(silent=True) or {}
+        progress = payload.get('progress', [])
+        data[username] = progress
+        save_data(data)
+        return jsonify({'status': 'ok'})
+
+    return jsonify({'progress': data.get(username, [])})
 
 if __name__ == '__main__':
     port = int(os.environ.get('PORT', 5000))

--- a/static/style.css
+++ b/static/style.css
@@ -170,7 +170,10 @@ body > style {
   display: none;
 }
 
-@media (max-width: 600px) {
+@media (max-width: 768px) {
+  .container {
+    padding: 10px;
+  }
   nav {
     flex-direction: column;
     align-items: center;

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,12 +3,21 @@
 <head>
     <meta charset="UTF-8">
     <title>Roadmap Cientista de Dados</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
 </head>
 <body>
+    {% if username %}
+    <p id="user-info">Logado como {{ username }} | <a href="{{ url_for('logout') }}">Logout</a></p>
+    {% else %}
+    <p><a href="{{ url_for('login') }}">Login</a></p>
+    {% endif %}
     <div class="container">
         {{ content|safe }}
     </div>
+    <script>
+        window.loggedIn = {{ "true" if username else "false" }};
+    </script>
     <script src="{{ url_for('static', filename='progress.js') }}"></script>
 </body>
 </html>

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="pt-br">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Login</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+    <div class="container">
+        <h2>Login</h2>
+        <form method="post">
+            <label for="username">Usuário:</label>
+            <input type="text" id="username" name="username" required>
+            <button type="submit">Entrar</button>
+        </form>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create a login page and JSON based storage
- persist progress on the server and expose `/progress` API
- show login status in the main page and indicate if user is logged in
- make layout responsive with viewport tag and CSS tweaks

## Testing
- `pip install -r requirements.txt`
- `python app.py`

------
https://chatgpt.com/codex/tasks/task_e_686ee7bb7680832da54a5bd707e01300